### PR TITLE
Ensure functions use single-line docstrings

### DIFF
--- a/cleanup.py
+++ b/cleanup.py
@@ -6,43 +6,13 @@ import bs4
 
 
 def read_file(file_path: str) -> str:
-    """
-    Read the contents of a file.
-
-    Args:
-        file_path: Path to the file to read.
-
-    Returns:
-        The contents of the file as a string.
-
-    Example:
-        >>> content = read_file("/path/to/file.txt")
-        >>> print(len(content))
-        1234
-    """
+    """Return the contents of a file as a string."""
     with open(file_path) as file:
         return file.read()
 
 
 def extract_html(json_object: Dict[str, Any]) -> str:
-    """
-    Extract primary HTML content from a judicial opinion JSON object.
-
-    Attempts to extract HTML content from various fields in order of preference:
-    html_with_citations, html_lawbox, html, html_columbia, and finally plain_text.
-
-    Args:
-        json_object: Dictionary containing judicial opinion data.
-
-    Returns:
-        HTML or plain text content from the opinion.
-
-    Example:
-        >>> opinion = {"html_with_citations": "<p>Court opinion...</p>"}
-        >>> html = extract_html(opinion)
-        >>> print(html[:10])
-        <p>Court o
-    """
+    """Extract primary HTML content from a judicial opinion JSON object."""
     if json_object["html_with_citations"]:
         return json_object["html_with_citations"]
     elif json_object["html_lawbox"]:
@@ -56,24 +26,7 @@ def extract_html(json_object: Dict[str, Any]) -> str:
 
 
 def is_well_formatted(html: str) -> bool:
-    """
-    Check if an opinion's HTML is well formatted.
-
-    Determines if HTML content is properly formatted by checking if it's non-empty,
-    starts with an HTML tag, and is not a preformatted text block.
-
-    Args:
-        html: HTML content to check.
-
-    Returns:
-        True if the HTML is well formatted, False otherwise.
-
-    Example:
-        >>> is_well_formatted("<p>Good HTML</p>")
-        True
-        >>> is_well_formatted("<pre>Bad HTML</pre>")
-        False
-    """
+    """Return True if HTML is non-empty, starts with a tag, and isn't preformatted."""
     return (
         len(html.strip()) > 0
         and bool(re.match("^<", html))
@@ -82,26 +35,7 @@ def is_well_formatted(html: str) -> bool:
 
 
 def clean_html(html: str) -> str:
-    """
-    Clean an opinion's HTML by removing metadata and extracting text content.
-
-    Removes superscript tags, fixes HTML entities, and extracts paragraph text
-    from the HTML content.
-
-    Args:
-        html: Raw HTML content to clean.
-
-    Returns:
-        Cleaned plain text with paragraphs separated by double newlines.
-
-    Example:
-        >>> html = "<p>First paragraph</p><sup>1</sup><p>Second paragraph</p>"
-        >>> clean_text = clean_html(html)
-        >>> print(clean_text)
-        First paragraph
-
-        Second paragraph
-    """
+    """Remove metadata from opinion HTML and extract paragraph text."""
     soup = bs4.BeautifulSoup(html, "html5lib")
 
     for tag in soup.find_all("sup"):
@@ -116,23 +50,7 @@ def clean_html(html: str) -> str:
 
 
 def extract_text(file_path: str) -> str:
-    """
-    Extract plain text from a judicial opinion JSON file.
-
-    Reads a JSON file containing a judicial opinion, extracts HTML content,
-    and returns cleaned plain text if the HTML is well formatted.
-
-    Args:
-        file_path: Path to the JSON file containing the judicial opinion.
-
-    Returns:
-        Cleaned plain text from the opinion, or empty string if not well formatted.
-
-    Example:
-        >>> text = extract_text("/path/to/opinion.json")
-        >>> print(text[:50])
-        The Supreme Court held that the defendant's rights...
-    """
+    """Extract cleaned plain text from a judicial opinion JSON file."""
     json_object = json.loads(read_file(file_path))
     raw_html = extract_html(json_object)
     if is_well_formatted(raw_html):

--- a/example.py
+++ b/example.py
@@ -60,25 +60,7 @@ K = 10  # number of neighbors to output
 
 
 def find_nearest_neighbors(model_file: str, word: str) -> None:
-    """
-    Find and print the K nearest neighbors of a word using Euclidean distance.
-
-    This function finds the K nearest neighbors of a given word using Euclidean
-    distance. It loads a trained GloVe model and prints the top K neighbors of
-    the query word along with their corresponding distances.
-
-    Args:
-        model_file: Path to the trained GloVe model file.
-        word: Query word to find neighbors for.
-
-    Returns:
-        None. Prints the nearest neighbors to stdout.
-
-    Example:
-        >>> find_nearest_neighbors("LeGlove.model", "legal")
-        The 10 nearest neighbors of legal are...
-        [('law', 0.123), ('court', 0.145), ...]
-    """
+    """Find and print the K nearest neighbors of a word using Euclidean distance."""
     print("The %d nearest neighbors of %s are..." % (K, word))
 
     # Load model and get dictionary (from word to word index) and word vectors
@@ -110,19 +92,7 @@ def find_nearest_neighbors(model_file: str, word: str) -> None:
 
 
 def main() -> None:
-    """
-    Main function to either train a new model or load an existing one for querying.
-
-    Parses command line arguments and either trains a new GloVe model from a corpus
-    or loads an existing model. Then finds and displays nearest neighbors for the
-    query word.
-
-    Returns:
-        None.
-
-    Raises:
-        ValueError: If neither training directory nor model file is provided.
-    """
+    """Train or load a model and display nearest neighbors for a query word."""
     args = parse_arguments()
 
     if not args.train_dir and not args.load_model:

--- a/train.py
+++ b/train.py
@@ -41,25 +41,7 @@ NUM_COMPONENTS = 100  # number of components/dimension of output word vectors
 
 
 def tokenize_text(plain_text: str) -> List[str]:
-    """
-    Tokenize and preprocess legal document text.
-
-    This function accepts a string representation of a legal document as input.
-    It returns a tokenized form of the input after preprocessing using legal
-    domain-specific regex patterns.
-
-    Args:
-        plain_text: Raw text content of a legal document.
-
-    Returns:
-        List of preprocessed tokens from the input text.
-
-    Example:
-        >>> text = "The court held in Smith v. Jones, 123 F.3d 456 (2020)..."
-        >>> tokens = tokenize_text(text)
-        >>> print(tokens[:3])
-        ['the', 'court', 'held']
-    """
+    """Tokenize legal text and replace regex matches with placeholder tokens."""
 
     # Clean plain text by replacing all regex matches
     # with corresponding tokens
@@ -75,24 +57,7 @@ def tokenize_text(plain_text: str) -> List[str]:
 
 
 def read_corpus(data_dir: str) -> Generator[List[str], None, None]:
-    """
-    Generate preprocessed tokens from all JSON files in the data directory.
-
-    This function returns a generator of lists of preprocessed tokens over all
-    JSON files in the given data directory. It processes files from all
-    jurisdiction-level subdirectories.
-
-    Args:
-        data_dir: Master directory containing jurisdiction-level subdirectories
-                 with JSON files containing legal opinions.
-
-    Yields:
-        List of preprocessed tokens for each valid legal document.
-
-    Example:
-        >>> for tokens in read_corpus("/path/to/data"):
-        ...     print(f"Document has {len(tokens)} tokens")
-    """
+    """Yield tokenized documents from JSON files in the given data directory."""
 
     num_files_read = 0
     for juris_dir in os.listdir(data_dir):
@@ -124,26 +89,7 @@ def train_and_save_model(
     num_epochs: int = 10,
     parallel_threads: int = 1,
 ) -> None:
-    """
-    Process legal corpus data and train a GloVe model.
-
-    This function processes all the data into a training corpus and fits a GloVe
-    model to this corpus. The trained model is saved to the current directory.
-
-    Args:
-        data_dir: Master directory containing all jurisdiction-level directories
-                 with JSON files containing legal opinions.
-        model_name: Name of model to be used for output file.
-        num_epochs: Number of epochs for which to train model.
-        parallel_threads: Number of parallel threads to use for training.
-
-    Returns:
-        None. The trained model is saved as "[model_name].model" in the current directory.
-
-    Example:
-        >>> train_and_save_model("/path/to/data", "MyModel", num_epochs=15)
-        # Creates "MyModel.model" file in current directory
-    """
+    """Process a legal corpus and train and save a GloVe model."""
 
     if Corpus is None or Glove is None:
         raise ImportError(


### PR DESCRIPTION
## Summary
- Condense verbose docstrings into single-line summaries for utility and training modules.
- Provide concise one-line descriptions for example script functions.

## Testing
- `pre-commit run --files example.py cleanup.py train.py`

------
https://chatgpt.com/codex/tasks/task_e_6893ed89a2008326871819142f004403