### PR TITLE
Use standard HTML unescape, clarify logging interval, zip regex tokens, parse CLI args as integers, and streamline neighbor mapping

### DIFF
--- a/leglove/cleanup.py
+++ b/leglove/cleanup.py
@@ -1,3 +1,4 @@
+import html
 import json
 import re
 from typing import Any, Dict
@@ -34,17 +35,15 @@ def is_well_formatted(html: str) -> bool:
     )
 
 
-def clean_html(html: str) -> str:
+def clean_html(html_content: str) -> str:
     """Remove metadata from opinion HTML and extract paragraph text."""
-    soup = bs4.BeautifulSoup(html, "html5lib")
+    soup = bs4.BeautifulSoup(html_content, "html5lib")
 
     for tag in soup.find_all("sup"):
         tag.extract()
-    html = str(soup)
-    html = re.sub("&amp;", "&", html)
-    html = re.sub("\xe2", "'", html)
+    html_text = html.unescape(str(soup))
 
-    soup = bs4.BeautifulSoup(html, "html5lib")
+    soup = bs4.BeautifulSoup(html_text, "html5lib")
     paragraphs = [paragraph.get_text() for paragraph in soup.find_all("p")]
     return "\n\n".join(paragraphs)
 

--- a/leglove/example.py
+++ b/leglove/example.py
@@ -38,11 +38,15 @@ def parse_arguments():
         "--model_name", default="LeGlove", help="Name for output model file"
     )
     parser.add_argument(
-        "--num_epochs", default=10, help="Train LeGlove model for this number of epochs"
+        "--num_epochs",
+        default=10,
+        type=int,
+        help="Train LeGlove model for this number of epochs",
     )
     parser.add_argument(
         "--parallel_threads",
         default=1,
+        type=int,
         help="Number of parallel threads to use for training",
     )
     parser.add_argument(
@@ -91,10 +95,7 @@ def find_nearest_neighbors(model_file: str, word: str) -> None:
     dictionary = model.dictionary
     word_vectors = model.word_vectors
 
-    word_to_vector = {}
-    for word in dictionary:
-        word_idx = dictionary[word]
-        word_to_vector[word] = word_vectors[word_idx]
+    word_to_vector = {w: word_vectors[dictionary[w]] for w in dictionary}
 
     # Find closest neighbors by Euclidean distance
     nbr_distances = []
@@ -124,8 +125,8 @@ def main() -> None:
         train_and_save_model(
             args.train_dir,
             model_name=args.model_name,
-            num_epochs=int(args.num_epochs),
-            parallel_threads=int(args.parallel_threads),
+            num_epochs=args.num_epochs,
+            parallel_threads=args.parallel_threads,
         )
         model_file = args.model_name + ".model"
 

--- a/leglove/train.py
+++ b/leglove/train.py
@@ -36,6 +36,7 @@ from .regexes import REGEX_TOKENS, REGEXES
 CONTEXT_WINDOW = 10  # length of the (symmetric)context window used for cooccurrence
 LEARNING_RATE = 0.05  # learning rate used for model training
 NUM_COMPONENTS = 100  # number of components/dimension of output word vectors
+LOG_INTERVAL = 1000  # number of files between progress logs
 
 
 ## LeGlove #####################################################################################
@@ -47,10 +48,8 @@ def tokenize_text(plain_text: str) -> List[str]:
     # Clean plain text by replacing all regex matches
     # with corresponding tokens
     cleaned_text = plain_text
-    for idx, regex in enumerate(REGEXES):
-        cleaned_text = re.sub(
-            regex, REGEX_TOKENS[idx], cleaned_text, flags=re.IGNORECASE
-        )
+    for regex, token in zip(REGEXES, REGEX_TOKENS):
+        cleaned_text = re.sub(regex, token, cleaned_text, flags=re.IGNORECASE)
 
     # Use NLTK tokenizer to return tokenized form of cleaned text
     tokens = word_tokenize(cleaned_text.lower())
@@ -74,8 +73,8 @@ def read_corpus(data_dir: str) -> Generator[List[str], None, None]:
             if not json_file.endswith(".json"):
                 continue
             num_files_read += 1
-            if num_files_read % 1e3 == 0:
-                logging.info(f"{int(num_files_read)} json files read...")
+            if num_files_read % LOG_INTERVAL == 0:
+                logging.info(f"{num_files_read} json files read...")
 
             json_file_path = os.path.join(juris_dir_path, json_file)
             plain_text = extract_text(json_file_path)

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -122,9 +122,9 @@ class TestCleanHtml:
 
     def test_clean_html_fix_entities(self) -> None:
         """Test fixing HTML entities."""
-        html = "<p>Text with &amp; ampersand</p>"
+        html = "<p>Text &amp; &quot;quoted&quot;</p>"
         result = clean_html(html)
-        assert result == "Text with & ampersand"
+        assert result == 'Text & "quoted"'
 
     def test_clean_html_empty(self) -> None:
         """Test cleaning empty HTML."""

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,5 +1,6 @@
 """Tests for the example module."""
 
+import logging
 from unittest.mock import Mock, patch
 
 import numpy as np
@@ -12,10 +13,12 @@ class TestFindNearestNeighbors:
     """Tests for the find_nearest_neighbors function."""
 
     @patch("leglove.example.Glove")
-    @patch("builtins.print")
     @patch("leglove.example.pprint")
     def test_find_nearest_neighbors_basic(
-        self, mock_pprint: Mock, mock_print: Mock, mock_glove_class: Mock
+        self,
+        mock_pprint: Mock,
+        mock_glove_class: Mock,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Test basic nearest neighbors functionality."""
         mock_model = Mock()
@@ -29,11 +32,12 @@ class TestFindNearestNeighbors:
         )
         mock_glove_class.load.return_value = mock_model
 
-        find_nearest_neighbors("test_model.model", "legal")
+        with caplog.at_level(logging.INFO):
+            find_nearest_neighbors("test_model.model", "legal")
 
         mock_glove_class.load.assert_called_once_with("test_model.model")
 
-        mock_print.assert_called_once_with("The 10 nearest neighbors of legal are...")
+        assert "The 10 nearest neighbors of legal are..." in caplog.text
 
         mock_pprint.pprint.assert_called_once()
 
@@ -88,8 +92,8 @@ class TestMain:
         mock_args.train_dir = "/path/to/data"
         mock_args.load_model = None
         mock_args.model_name = "TestModel"
-        mock_args.num_epochs = "15"
-        mock_args.parallel_threads = "4"
+        mock_args.num_epochs = 15
+        mock_args.parallel_threads = 4
         mock_args.query = "legal"
         mock_parse_args.return_value = mock_args
 
@@ -145,8 +149,8 @@ class TestMain:
         mock_args.train_dir = "/path/to/data"
         mock_args.load_model = None
         mock_args.model_name = "LeGlove"  # Default value
-        mock_args.num_epochs = "10"  # Default value
-        mock_args.parallel_threads = "1"  # Default value
+        mock_args.num_epochs = 10  # Default value
+        mock_args.parallel_threads = 1  # Default value
         mock_args.query = "legal"
         mock_parse_args.return_value = mock_args
 


### PR DESCRIPTION
## Summary
- Replace manual HTML entity replacements with `html.unescape` for broader coverage
- Expand tests to verify unescaping of quotation entities
- Introduce `LOG_INTERVAL` constant in `read_corpus` to use integer modulo for progress logging
- Iterate over regex and token pairs in `tokenize_text` to avoid index mismatches
- Parse numeric command-line options as integers, eliminating manual casts
- Build `word_to_vector` via a dictionary comprehension in `find_nearest_neighbors` for conciseness

## Testing
- `NLTK_DATA=/root/nltk_data uv run pre-commit run --files leglove/example.py tests/test_example.py tests/test_train.py tests/test_cleanup.py`
- `NLTK_DATA=/root/nltk_data uv run pytest tests/test_example.py tests/test_train.py tests/test_cleanup.py`


------
https://chatgpt.com/codex/tasks/task_e_68948bb7922c8326ba33df7021de36c8